### PR TITLE
🐛 GDB version >= 9

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,15 +6,19 @@
 	"context": "..",
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"dockerFile": "../Dockerfile",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-vscode.cpptools",
-		"ms-vscode.cmake-tools",
-		"twxs.cmake",
-		"marus25.cortex-debug",
-	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools",
+				"twxs.cmake",
+				"marus25.cortex-debug"
+			]
+		},
+		// Set *default* container specific settings.json values on container create.
+		"settings": {}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
@@ -25,7 +29,7 @@
 		"--security-opt",
 		"seccomp=unconfined",
 		"--privileged"
-	],
+	]
 	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
 	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get install \
 
 
 # Install arm-none-eabi compiler
-RUN wget https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.3.1-1.1/xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x64.tar.gz
-RUN tar xf xpack-arm-none-eabi-gcc-9.3.1-1.1-linux-x64.tar.gz
-RUN cp -rf xpack-arm-none-eabi-gcc-9.3.1-1.1/* /usr/local/
-RUN rm -rf xpack-arm-none-eabi-gcc-9.3.1-1.1
+RUN wget https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v13.2.1-1.1/xpack-arm-none-eabi-gcc-13.2.1-1.1-linux-x64.tar.gz \
+    && tar xf xpack-arm-none-eabi-gcc-13.2.1-1.1-linux-x64.tar.gz \
+    && cp -rf xpack-arm-none-eabi-gcc-13.2.1-1.1/* /usr/local/ \
+    && rm -rf xpack-arm-none-eabi-gcc-13.2.1-1.1*
 
 # build openocd from source
 RUN git clone https://github.com/openocd-org/openocd.git \


### PR DESCRIPTION
**Dockerfile**
`v9.3.1-1.1` version of `xpack-arm-none-eabi-gcc` contains version `8.x` of `arm-none-eabi-gdb`, this throws an error that it has to be `>= 9`.
To fix this update to `xpack-arm-none-eabi-gcc-13.2.1-1.1` which is the newes as of date.

**devcontainer.json** 
🎨 Formatting according to VSCode complaints.